### PR TITLE
Ret T2750 : couleur badge poste en orange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,4 +10,5 @@ Version 3.1 (2021-02-09)
 #Changed
 
 - FIX Exclude current contact to network search list
+- FIX Poste Badge orange color
 

--- a/core/modules/modNetwork.class.php
+++ b/core/modules/modNetwork.class.php
@@ -60,7 +60,7 @@ class modNetwork extends DolibarrModules
 		// Module description, used if translation string 'ModuleXXXDesc' not found (where XXX is value of numeric property 'numero' of module)
 		$this->description = $langs->trans('Module900000092Desc');
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
-		$this->version = '3.1.0';
+		$this->version = '3.1.1';
 		// Key used in llx_const table to save module status enabled/disabled (where NETWORK is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
 		// Where to store the module in setup page (0=common,1=interface,2=others,3=very specific)

--- a/css/network.css
+++ b/css/network.css
@@ -118,6 +118,10 @@
     background-color: #9A3BF9;
 }
 
+#network-comments .network-badge-poste {
+    background-color: #FF6400;
+}
+
 #network-comments .network_badge.user, #network-comments .network_badge.usergroup {
     background-color: #3C70A4;
 }

--- a/js/network.js.php
+++ b/js/network.js.php
@@ -156,7 +156,7 @@ if (!empty($user->rights->network->read)) {
                     $comment.append('<span class="rel badge network_badge network-badge-link">'+data[i].link+'</span>');
 
                     $comment.append(data[i].url);
-					if(data[i].poste != undefined) $comment.append('<span class="rel badge network_badge network-badge-link">'+data[i].poste+'</span>');
+					if(data[i].poste != undefined) $comment.append('<span class="rel badge network_badge network-badge-poste">'+data[i].poste+'</span>');
                     <?php
                     if (!empty($user->rights->network->delete)) {
                     ?>


### PR DESCRIPTION
Badge "poste" de couleur orange car il était de la même couleur que le badge "lien"